### PR TITLE
t_drain can be array of length Nx, Closes #48

### DIFF
--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Tuple
+from typing import Tuple, Union
 from nptyping import NDArray
 import numpy as np
 
@@ -19,7 +19,7 @@ class Blob:
         pos_x: float,
         pos_y: float,
         t_init: float,
-        t_drain: float,
+        t_drain: Union[float, NDArray],
     ) -> None:
         self.int = int
         self.blob_id = blob_id

--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -136,7 +136,9 @@ class Blob:
         )
 
     def _drain(self, t: NDArray) -> NDArray:
-        return np.exp(-(t - self.t_init) / self.t_drain)
+        if isinstance(self.t_drain, (int, float)):
+            return np.exp(-(t - self.t_init) / self.t_drain)
+        return np.exp(-(t - self.t_init) / self.t_drain[np.newaxis, :, np.newaxis])
 
     def _blob_arrival(self, t: NDArray) -> NDArray:
         return np.heaviside(t - self.t_init, 1)
@@ -164,7 +166,7 @@ class Blob:
             return np.exp(x_diffs) * np.heaviside(-1.0 * (x_diffs), 1)
         else:
             raise NotImplementedError(
-                self.__class__.__name__ + ".blob_shape not implemented"
+                f"{self.__class__.__name__}.blob_shape not implemented"
             )
 
     def _perpendicular_direction_shape(

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -69,6 +69,11 @@ class Model:
         self.blob_shape: str = blob_shape
         self.num_blobs: int = num_blobs
         self.t_drain: Union[float, NDArray] = t_drain
+
+        assert (
+            isinstance(t_drain, (int, float)) or len(t_drain) == Nx
+        ), "t_drain must be of either length 1 or Nx"
+
         self._blobs: list[Blob] = []
         self._blob_factory = blob_factory
         self._density = np.zeros(

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -1,10 +1,11 @@
 import numpy as np
 import xarray as xr
 from tqdm import tqdm
-from typing import List
+from typing import List, Union
 from .blobs import Blob
 from .stochasticality import BlobFactory, DefaultBlobFactory
 from .geometry import Geometry
+from nptyping import NDArray
 
 
 class Model:
@@ -21,7 +22,7 @@ class Model:
         periodic_y: bool = False,
         blob_shape: str = "gauss",
         num_blobs: int = 1000,
-        t_drain: float = 10,
+        t_drain: Union[float, NDArray] = 10,
         blob_factory: BlobFactory = DefaultBlobFactory(),
         labels: str = "off",
         label_border: float = 0.75,
@@ -43,7 +44,7 @@ class Model:
             number of blobs
         blob_shape: str, optional
             see Blob dataclass for available shapes
-        t_drain: float, optional
+        t_drain: float or array of length Nx, optional
             drain time for blobs
         blob_factory: BlobFactory, optional
             sets distributions of blob parameters
@@ -67,7 +68,7 @@ class Model:
         )
         self.blob_shape: str = blob_shape
         self.num_blobs: int = num_blobs
-        self.t_drain: float = t_drain
+        self.t_drain: Union[float, NDArray] = t_drain
         self._blobs: list[Blob] = []
         self._blob_factory = blob_factory
         self._density = np.zeros(

--- a/examples/1d_animation.py
+++ b/examples/1d_animation.py
@@ -11,7 +11,7 @@ bm = Model(
     T=10,
     periodic_y=False,
     blob_shape="exp",
-    num_blobs=10,
+    num_blobs=20,
     t_drain=10,
     blob_factory=bf,
 )

--- a/examples/changing_t_drain.py
+++ b/examples/changing_t_drain.py
@@ -30,7 +30,7 @@ def plot_cahnging_t_drain(ds):
     t_w = 1 / 10
     amp = 1
     v_p = 1.0
-    t_loss = 2.0
+    t_loss = t_drain
     t_d = t_loss * t_p / (t_loss + t_p)
 
     analytical_profile = (

--- a/examples/changing_t_drain.py
+++ b/examples/changing_t_drain.py
@@ -1,0 +1,47 @@
+from blobmodel import Model, DefaultBlobFactory
+import matplotlib.pyplot as plt
+import numpy as np
+
+bf = DefaultBlobFactory(A_dist="deg", W_dist="deg", vx_dist="deg", vy_dist="zeros")
+
+t_drain = np.linspace(2, 1, 100)
+
+tmp = Model(
+    Nx=100,
+    Ny=1,
+    Lx=10,
+    Ly=0,
+    dt=1,
+    T=1000,
+    blob_shape="exp",
+    t_drain=t_drain,
+    periodic_y=False,
+    num_blobs=10000,
+    blob_factory=bf,
+)
+
+ds = tmp.make_realization(file_name="profile_comparison.nc", speed_up=True, error=1e-2)
+
+
+def plot_cahnging_t_drain(ds):
+
+    x = np.linspace(0, 10, 100)
+    t_p = 1
+    t_w = 1 / 10
+    amp = 1
+    v_p = 1.0
+    t_loss = 2.0
+    t_d = t_loss * t_p / (t_loss + t_p)
+
+    analytical_profile = (
+        1 / np.sqrt(np.pi) * t_d / t_w * amp * np.exp(-x / (v_p * t_loss))
+    )
+
+    ds.n.isel(y=0).mean(dim=("t")).plot(label="decreasing t_drain")
+    plt.yscale("log")
+    plt.plot(x, analytical_profile, label="constant t_drain")
+    plt.legend()
+    plt.show()
+
+
+plot_cahnging_t_drain(ds)

--- a/tests/test_changing_t_drain.py
+++ b/tests/test_changing_t_drain.py
@@ -1,0 +1,48 @@
+from blobmodel import Model, DefaultBlobFactory
+import xarray as xr
+import numpy as np
+
+
+# use DefaultBlobFactory to define distribution functions fo random variables
+bf = DefaultBlobFactory(A_dist="deg", W_dist="deg", vx_dist="deg", vy_dist="zeros")
+
+t_drain = np.linspace(2, 1, 10)
+
+tmp = Model(
+    Nx=10,
+    Ny=1,
+    Lx=10,
+    Ly=0,
+    dt=1,
+    T=1000,
+    blob_shape="exp",
+    t_drain=t_drain,
+    periodic_y=False,
+    num_blobs=10000,
+    blob_factory=bf,
+)
+
+
+tmp.make_realization(file_name="test_t_drain.nc", speed_up=True, error=1e-2)
+
+
+def test_decreasing_t_drain():
+
+    ds = xr.open_dataset("test_t_drain.nc")
+    model_profile = ds.n.isel(y=0).mean(dim=("t"))
+
+    x = np.linspace(0, 10, 10)
+    t_p = 1
+    t_w = 1 / 10
+    amp = 1
+    v_p = 1.0
+    t_loss = 2.0
+    t_d = t_loss * t_p / (t_loss + t_p)
+
+    analytical_profile = (
+        1 / np.sqrt(np.pi) * t_d / t_w * amp * np.exp(-x / (v_p * t_loss))
+    )
+    assert (model_profile.values[2:] < analytical_profile[2:]).all()
+
+
+test_decreasing_t_drain()


### PR DESCRIPTION
Changing `t_drain` enabled. Relevant for comparisons to experimental data where the drainage time typically decreases with rho. 

@Sosnowsky the `assert` statement in `model.py` looks a bit out of place but we should have added multiple assert statements from the beginning I think. Any thoughts?